### PR TITLE
Update table for iOS supported versions

### DIFF
--- a/appstore/statistics/2015/02/13/fr-appstore-supported-ios-version.html
+++ b/appstore/statistics/2015/02/13/fr-appstore-supported-ios-version.html
@@ -341,7 +341,7 @@ Apple “controls” the supported version of iOS by the configuration of the mi
     <tr>
       <td style="text-align: left">Code limitation : childViewController missing</td>
       <td style="text-align: center">x</td>
-      <td style="text-align: center">x</td>
+      <td style="text-align: center"> </td>
       <td style="text-align: center"> </td>
       <td style="text-align: center"> </td>
       <td style="text-align: center"> </td>


### PR DESCRIPTION
ChildViewController mechanism exists since iOS 5.0
